### PR TITLE
[!pr] KIN-71: Updating CircleCI to store test output as xml.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,13 @@ jobs:
             - "./Carthage"
       - run:
           name: execute tests
-          command: fastlane scan --scheme "Unleash" --device "iPhone X" --clean
+          command: |
+            mkdir -p ~/test-results/xctest/
+            fastlane scan --scheme "Unleash" --device "iPhone X" --clean --output_directory="~/test-results/xctest/" --output_types="junit" --output_files="junit.xml"
       - store_test_results:
-          path: /tmp/test-results
+          path: ~/test-results
       - store_artifacts:
-          path: /tmp/test-results
+          path: ~/test-results
           destination: scan-test-results
       - store_artifacts:
           path: ~/Library/Logs/scan


### PR DESCRIPTION
#### Purpose
- [ ] Feature
- [ ] Bug Fix
- [ ] Hotfix
- [X] Other

#### Associated Tickets
- [Store test results](https://silvercar.atlassian.net/browse/KIN-71)

#### Details
- Updated CircleCI to [store test metadata](https://circleci.com/docs/2.0/collect-test-data/#gradle-junit-results)

#### Checklist
- [ ] Tests
- [X] Correct base and merge branches
