### PR TITLE
KIN-71: Adding retry to register call

### DIFF
--- a/unleash/Models/ClientRegistration.swift
+++ b/unleash/Models/ClientRegistration.swift
@@ -17,6 +17,7 @@ final class ClientRegistration: Codable {
     
     init(appName: String, strategies: [Strategy]) {
         self.appName = appName
+        // TODO: This shouldn't be re-generated per instance of the library, need to store this value and re-use 
         self.instanceId = UUID().uuidString
         self.sdkVersion = "unleash-client-ios:\(AppInfo.shortVersion)"
         self.strategies = strategies.map { $0.getName() }

--- a/unleash/Services/RegisterService.swift
+++ b/unleash/Services/RegisterService.swift
@@ -20,7 +20,8 @@ extension RegisterService {
         return firstly {
             URLSession.shared.dataTask(.promise, with: try makeUrlRequest(url: registerUrl, body: body)).validate()
         }.map {
-            try JSONSerialization.jsonObject(with: $0.data) as? [String: Any]
+            // Unleash will return 200 and then 202 when already registered
+            return $0.data.isEmpty ? [:] : try JSONSerialization.jsonObject(with: $0.data) as? [String: Any]
         }
     }
     


### PR DESCRIPTION
#### Purpose
- [X] Feature
- [ ] Bug Fix
- [ ] Hotfix
- [ ] Other

#### Associated Tickets
- [Retry register call on failure](https://silvercar.atlassian.net/browse/KIN-71)

#### Details
- Updating register call to retry if a failure is returned using PromiseKit
- Update the service call to handle 202, no body response.

#### Checklist
- [ ] Tests
- [ ] Correct base and merge branches
