### PR TITLE
KIN-71: Updating Strategy protocol to use property for name.

### DIFF
--- a/unleash/Models/ClientRegistration.swift
+++ b/unleash/Models/ClientRegistration.swift
@@ -20,7 +20,7 @@ final class ClientRegistration: Codable {
         // TODO: This shouldn't be re-generated per instance of the library, need to store this value and re-use 
         self.instanceId = UUID().uuidString
         self.sdkVersion = "unleash-client-ios:\(AppInfo.shortVersion)"
-        self.strategies = strategies.map { $0.getName() }
+        self.strategies = strategies.map { $0.name }
         self.started = Date().iso8601DateString
         self.interval = 10_000
     }

--- a/unleash/Strategies/DefaultStrategy.swift
+++ b/unleash/Strategies/DefaultStrategy.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class DefaultStrategy : Strategy {
-    func getName() -> String {
+    var name: String {
         return "default"
     }
     

--- a/unleash/Unleash.swift
+++ b/unleash/Unleash.swift
@@ -10,7 +10,7 @@ import PMKFoundation
 import PromiseKit
 
 public protocol Strategy {
-    func getName() -> String
+    var name: String { get }
     func isEnabled(parameters: [String: String]) -> Bool
 }
 

--- a/unleashTests/Models/ClientRegistrationSpec.swift
+++ b/unleashTests/Models/ClientRegistrationSpec.swift
@@ -41,16 +41,14 @@ class ClientRegistrationSpec: QuickSpec {
                     let result = ClientRegistration(appName: appName, strategies: strategies).strategies
                     
                     // Assert
-                    expect(result).to(contain(strategy.getName()))
+                    expect(result).to(contain(strategy.name))
                 }
             }
         }
     }
     
     class TestStrategy: Strategy {
-        func getName() -> String {
-            return "test strategy"
-        }
+        var name = "test strategy"
         
         func isEnabled(parameters: [String : String]) -> Bool {
             return false

--- a/unleashTests/Strategies/DefaultStrategySpec.swift
+++ b/unleashTests/Strategies/DefaultStrategySpec.swift
@@ -23,7 +23,7 @@ class DefaultStrategySpec: QuickSpec {
             context("when default initializer") {
                 it("returns default for name") {
                     // Act
-                    let result = strategy.getName()
+                    let result = strategy.name
                     
                     // Assert
                     expect(result).to(equal("default"))


### PR DESCRIPTION
#### Purpose
- [X] Feature
- [ ] Bug Fix
- [ ] Hotfix
- [ ] Other

#### Associated Tickets
- [Strategy change name to property](https://silvercar.atlassian.net/browse/KIN-71)

#### Details
- Updated Strategy protocol to use a property for name

#### Checklist
- [ ] Tests
- [ ] Correct base and merge branches
