### PR TITLE
KIN-79: Updating Unleash to use ToggleRepository.

### DIFF
--- a/UnleashSampleApp/ViewController.swift
+++ b/UnleashSampleApp/ViewController.swift
@@ -19,7 +19,10 @@ class ViewController: UIViewController {
                                        url: "https://unleash.silvercar.com/api",
                                        refreshInterval: 300000,
                                        strategies: [EnvironmentStrategy()])
-        self.isFeatureEnabled?.text = "\(unleash.isEnabled(name: "enable-auth0-in-admin-client"))"
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.isFeatureEnabled?.text = "\(unleash.isEnabled(name: "enable-auth0-in-admin-client"))"
+        }
     }
 }
 

--- a/unleash.xcodeproj/project.pbxproj
+++ b/unleash.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		9D7606592314D3D200B4217F /* ToggleRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7606582314D3D200B4217F /* ToggleRepositorySpec.swift */; };
 		9D76065A2314D56C00B4217F /* MemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D22731E23109EAD001CDD08 /* MemoryCache.swift */; };
 		9D76065B2314D56F00B4217F /* ToggleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7606562314D2FE00B4217F /* ToggleRepository.swift */; };
+		9D76065F2315DB5E00B4217F /* ToggleRespositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D76065E2315DB5E00B4217F /* ToggleRespositoryMock.swift */; };
+		9D7606612316172600B4217F /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7606602316172600B4217F /* TestError.swift */; };
 		9DEA495722D7EE8C006FB13A /* Unleash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DEA494D22D7EE8C006FB13A /* Unleash.framework */; };
 		9DEA495E22D7EE8C006FB13A /* Unleash.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DEA495022D7EE8C006FB13A /* Unleash.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -163,6 +165,8 @@
 		9D76064C2314258C00B4217F /* MemoryCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoryCacheSpec.swift; path = unleashTests/Data/MemoryCacheSpec.swift; sourceTree = SOURCE_ROOT; };
 		9D7606562314D2FE00B4217F /* ToggleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ToggleRepository.swift; path = unleash/ToggleRepository.swift; sourceTree = SOURCE_ROOT; };
 		9D7606582314D3D200B4217F /* ToggleRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ToggleRepositorySpec.swift; path = unleashTests/ToggleRepositorySpec.swift; sourceTree = SOURCE_ROOT; };
+		9D76065E2315DB5E00B4217F /* ToggleRespositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ToggleRespositoryMock.swift; path = unleashTests/ToggleRespositoryMock.swift; sourceTree = SOURCE_ROOT; };
+		9D7606602316172600B4217F /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestError.swift; path = unleashTests/TestError.swift; sourceTree = SOURCE_ROOT; };
 		9DEA494D22D7EE8C006FB13A /* Unleash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Unleash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DEA495022D7EE8C006FB13A /* Unleash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Unleash.h; sourceTree = "<group>"; };
 		9DEA495122D7EE8C006FB13A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -359,6 +363,8 @@
 				9D2C1CBF22D97B8000721A2D /* Date+ExtensionSpec.swift */,
 				9D7606582314D3D200B4217F /* ToggleRepositorySpec.swift */,
 				9D1C642F22DEB5480069FD45 /* UnleashSpec.swift */,
+				9D7606602316172600B4217F /* TestError.swift */,
+				9D76065E2315DB5E00B4217F /* ToggleRespositoryMock.swift */,
 			);
 			path = UnleashTests;
 			sourceTree = "<group>";
@@ -558,6 +564,8 @@
 				9D1C646E22E0E09D0069FD45 /* Toggles.swift in Sources */,
 				9D2FBD30230F16CD000BAAF9 /* VariantDefinitionBuilder.swift in Sources */,
 				9D1C642E22DE80220069FD45 /* DefaultStrategySpec.swift in Sources */,
+				9D76065F2315DB5E00B4217F /* ToggleRespositoryMock.swift in Sources */,
+				9D7606612316172600B4217F /* TestError.swift in Sources */,
 				9D2FBD2E230F167F000BAAF9 /* VariantOverrideBuilder.swift in Sources */,
 				9D1C646822E0D7800069FD45 /* VariantOverride.swift in Sources */,
 				9D2C1CB922D9787C00721A2D /* AppInfo.swift in Sources */,

--- a/unleashTests/Models/FeatureBuilder.swift
+++ b/unleashTests/Models/FeatureBuilder.swift
@@ -8,11 +8,18 @@
 import Foundation
 
 class FeatureBuilder {
+    private var name = "feature-one"
+    
+    func withName(name: String) -> FeatureBuilder {
+        self.name = name
+        return self
+    }
+    
     func build() -> Feature {
         let strategy: ActivationStrategy = ActivationStrategyBuilder().withName(name: "default").build()
         let variant: VariantDefinition = VariantDefinitionBuilder().build()
         
-        return Feature(name: "feature-one", description: "Feature one", enabled: true, strategies: [strategy],
+        return Feature(name: name, description: "Feature one", enabled: true, strategies: [strategy],
                        variants: [variant], createdAt: "2019-06-05T19:22:36.027Z")
     }
 }

--- a/unleashTests/Models/TogglesBuilder.swift
+++ b/unleashTests/Models/TogglesBuilder.swift
@@ -8,7 +8,17 @@
 import Foundation
 
 class TogglesBuilder {
+    private var features: [Feature] = []
+    
+    func withFeature(feature: Feature) -> TogglesBuilder {
+        self.features.append(feature)
+        return self
+    }
+    
     func build() -> Toggles {
-        return Toggles(version: 10, features: [FeatureBuilder().build()])
+        if (features.isEmpty) {
+            features.append(FeatureBuilder().build())
+        }
+        return Toggles(version: 10, features: features)
     }
 }

--- a/unleashTests/TestError.swift
+++ b/unleashTests/TestError.swift
@@ -1,0 +1,12 @@
+//
+//  TestError.swift
+//  UnleashTests
+//
+//  Copyright © 2019 Silvercar. All rights reserved.
+//
+
+import Foundation
+
+enum TestError: Swift.Error {
+    case error
+}

--- a/unleashTests/ToggleRepositorySpec.swift
+++ b/unleashTests/ToggleRepositorySpec.swift
@@ -22,39 +22,41 @@ class ToggleRepositorySpec: QuickSpec {
             return ToggleRepository(memory: memory!, toggleService: toggleService!)
         }
         
-        describe("#get") {
+        describe("#toggles") {
+            beforeEach {
+                memory = MemoryCache(cache: Cache(), jsonDecoder: JSONDecoder(), jsonEncoder: JSONEncoder())
+                toggleService = ToggleServiceMock(promise: Promise<Toggles>.init(error: TestError.error))
+            }
+            
             context("when has cached toggles") {
                 it("return cached toggles") {
                     // Arrange
-                    memory = MemoryCache(cache: Cache(), jsonDecoder: JSONDecoder(), jsonEncoder: JSONEncoder())
                     memory?.put(for: "unleash-feature-toggles", value: toggles)
                     
-                    enum Error: Swift.Error {
-                        case error
-                    }
-                    toggleService = ToggleServiceMock(promise: Promise<Toggles>.init(error: Error.error))
+                    // Act
+                    let result = repository.toggles
                     
-                    // Act/Assert
-                    waitUntil { done in
-                        repository.get(url: url)
-                            .done { toggles in
-                                expect(toggles).toNot(beNil())
-                                done()
-                            }.catch { _ in
-                                fail()
-                        }
-                    }
+                    // Assert
+                    expect(result).toNot(beNil())
                 }
             }
             
-            context("when no cached toggles") {
-                it("return toggles from API") {
+            context("when does not have cached toggles") {
+                it("return optional") {
+                    // Act
+                    let result = repository.toggles
+                    
+                    // Assert
+                    expect(result).to(beNil())
+                }
+            }
+        }
+        
+        describe("#get") {
+            context("when given toggles url") {
+                it("return toggles") {
                     // Arrange
                     memory = MemoryCache(cache: Cache(), jsonDecoder: JSONDecoder(), jsonEncoder: JSONEncoder())
-                    
-                    enum Error: Swift.Error {
-                        case error
-                    }
                     toggleService = ToggleServiceMock(promise: Promise<Toggles>.value(toggles))
                     
                     // Act/Assert

--- a/unleashTests/ToggleRespositoryMock.swift
+++ b/unleashTests/ToggleRespositoryMock.swift
@@ -1,0 +1,24 @@
+//
+//  ToggleRespositoryMock.swift
+//  UnleashTests
+//
+//  Copyright © 2019 Silvercar. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+
+class ToggleRepositoryMock: ToggleRepositoryProtocol {
+    var toggles: Toggles?
+    
+    init(toggles: Toggles?) {
+        self.toggles = toggles
+    }
+    
+    func get(url: URL) -> Promise<Toggles> {
+        if let toggles = self.toggles {
+            return Promise.value(toggles)
+        }
+        return Promise.init(error: TestError.error)
+    }
+}


### PR DESCRIPTION
#### Purpose
- [X] Feature
- [ ] Bug Fix
- [ ] Hotfix
- [ ] Other

#### Associated Tickets
- [Unleash use ToggleRepository](https://silvercar.atlassian.net/browse/KIN-79)

#### Details
- Updated ToggleRepository to use a computed property to set cached Toggles
- Updated Unleash to use ToggleRepository vs. ToggleService and use computed property to access current cached Toggles
- Added mock for ToggleRepository
- Updated some of the test data builders to set some more fields

#### Checklist
- [X] Tests
- [ ] Correct base and merge branches
