### PR TITLE
KIN-79 Use Strategies for Feature Toggles

### DIFF
--- a/UnleashSampleApp/ViewController.swift
+++ b/UnleashSampleApp/ViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Unleash
 
 // This constant is to emulate a client knowing its target environment is (e.g. QA, Production)
-enum Constants {
+struct Constants {
     static let environment: String = "QA"
 }
 

--- a/UnleashSampleApp/ViewController.swift
+++ b/UnleashSampleApp/ViewController.swift
@@ -8,6 +8,11 @@
 import UIKit
 import Unleash
 
+// This constant is to emulate a client knowing its target environment is (e.g. QA, Production)
+enum Constants {
+    static let environment: String = "QA"
+}
+
 class ViewController: UIViewController {
     //MARK: Properties
     @IBOutlet internal weak var isFeatureEnabled: UILabel!
@@ -32,6 +37,7 @@ class EnvironmentStrategy: Strategy {
     }
     
     func isEnabled(parameters: [String : String]) -> Bool {
-        return "QA" == parameters["environment"]
+        return Constants.environment == parameters["environment"]
     }
 }
+

--- a/unleash/Unleash.swift
+++ b/unleash/Unleash.swift
@@ -83,6 +83,21 @@ public class Unleash {
     }
     
     public func isEnabled(name: String) -> Bool {
-        return toggles?.features.first { $0.name == name }?.enabled ?? false
+        guard let feature = toggles?.features.first(where: { $0.name == name }) else { return false }
+        
+        if !feature.enabled {
+            return false
+        }
+        
+        for strategy in feature.strategies {
+            guard let targetStrategy = strategies.first(where: { $0.name == strategy.name }) else { continue }
+            guard let parameters = strategy.parameters else { continue }
+            
+            if targetStrategy.isEnabled(parameters: parameters) {
+                return true
+            }
+        }
+        
+        return false
     }
 }

--- a/unleashTests/Models/ActivationStrategyBuilder.swift
+++ b/unleashTests/Models/ActivationStrategyBuilder.swift
@@ -16,6 +16,6 @@ class ActivationStrategyBuilder {
     }
     
     func build() -> ActivationStrategy {
-        return ActivationStrategy(name: name, parameters: nil)
+        return ActivationStrategy(name: name, parameters: [:])
     }
 }

--- a/unleashTests/Models/FeatureBuilder.swift
+++ b/unleashTests/Models/FeatureBuilder.swift
@@ -9,15 +9,15 @@ import Foundation
 
 class FeatureBuilder {
     private var name = "feature-one"
-    private var enabled = true
+    private var isEnabled = true
     
     func withName(name: String) -> FeatureBuilder {
         self.name = name
         return self
     }
     
-    func disabled() -> FeatureBuilder {
-        self.enabled = false
+    func disable() -> FeatureBuilder {
+        self.isEnabled = false
         return self
     }
     
@@ -25,7 +25,7 @@ class FeatureBuilder {
         let strategy: ActivationStrategy = ActivationStrategyBuilder().withName(name: "default").build()
         let variant: VariantDefinition = VariantDefinitionBuilder().build()
         
-        return Feature(name: name, description: "Feature one", enabled: enabled, strategies: [strategy],
+        return Feature(name: name, description: "Feature one", enabled: isEnabled, strategies: [strategy],
                        variants: [variant], createdAt: "2019-06-05T19:22:36.027Z")
     }
 }

--- a/unleashTests/Models/FeatureBuilder.swift
+++ b/unleashTests/Models/FeatureBuilder.swift
@@ -9,9 +9,15 @@ import Foundation
 
 class FeatureBuilder {
     private var name = "feature-one"
+    private var enabled = true
     
     func withName(name: String) -> FeatureBuilder {
         self.name = name
+        return self
+    }
+    
+    func disabled() -> FeatureBuilder {
+        self.enabled = false
         return self
     }
     
@@ -19,7 +25,7 @@ class FeatureBuilder {
         let strategy: ActivationStrategy = ActivationStrategyBuilder().withName(name: "default").build()
         let variant: VariantDefinition = VariantDefinitionBuilder().build()
         
-        return Feature(name: name, description: "Feature one", enabled: true, strategies: [strategy],
+        return Feature(name: name, description: "Feature one", enabled: enabled, strategies: [strategy],
                        variants: [variant], createdAt: "2019-06-05T19:22:36.027Z")
     }
 }

--- a/unleashTests/UnleashSpec.swift
+++ b/unleashTests/UnleashSpec.swift
@@ -107,7 +107,7 @@ class UnleashSpec : QuickSpec {
                         let name = "feature"
                         let feature = FeatureBuilder()
                             .withName(name: name)
-                            .disabled()
+                            .disable()
                             .build()
                         let toggles = TogglesBuilder()
                             .withFeature(feature: feature)

--- a/unleashTests/UnleashSpec.swift
+++ b/unleashTests/UnleashSpec.swift
@@ -23,7 +23,7 @@ class UnleashSpec : QuickSpec {
         var unleash: Unleash {
             return Unleash(clientRegistration: clientRegistration, registerService: registerService!,
                            toggleRepository: toggleRepository!, appName: appName, url: url, refreshInterval: interval,
-                           strategies: [])
+                           strategies: [DefaultStrategy()])
         }
         
         beforeEach {
@@ -49,7 +49,7 @@ class UnleashSpec : QuickSpec {
                     expect(result.appName).to(equal(appName))
                     expect(result.url).to(equal(url))
                     expect(result.refreshInterval).to(equal(interval))
-                    expect(result.strategies).to(beEmpty())
+                    expect(result.strategies.count).to(equal(1))
                 }
                 
                 it("sets client registration") {
@@ -101,22 +101,45 @@ class UnleashSpec : QuickSpec {
         
         describe("#isEnabled") {
             context("when toggles cached") {
-                it("return toggles enabled value") {
-                    // Arrange
-                    let name = "feature"
-                    let feature = FeatureBuilder()
-                        .withName(name: name)
-                        .build()
-                    let toggles = TogglesBuilder()
-                        .withFeature(feature: feature)
-                        .build()
-                    toggleRepository = ToggleRepositoryMock(toggles: toggles)
-                    
-                    // Act
-                    let result = unleash.isEnabled(name: name)
-                    
-                    // Assert
-                    expect(result).to(beTrue())
+                context("when feature disabled") {
+                    it("return false") {
+                        // Arrange
+                        let name = "feature"
+                        let feature = FeatureBuilder()
+                            .withName(name: name)
+                            .disabled()
+                            .build()
+                        let toggles = TogglesBuilder()
+                            .withFeature(feature: feature)
+                            .build()
+                        toggleRepository = ToggleRepositoryMock(toggles: toggles)
+                        
+                        // Act
+                        let result = unleash.isEnabled(name: name)
+                        
+                        // Assert
+                        expect(result).to(beFalse())
+                    }
+                }
+                
+                context("when feature enabled") {
+                    it("return toggles enabled value") {
+                        // Arrange
+                        let name = "feature"
+                        let feature = FeatureBuilder()
+                            .withName(name: name)
+                            .build()
+                        let toggles = TogglesBuilder()
+                            .withFeature(feature: feature)
+                            .build()
+                        toggleRepository = ToggleRepositoryMock(toggles: toggles)
+                        
+                        // Act
+                        let result = unleash.isEnabled(name: name)
+                        
+                        // Assert
+                        expect(result).to(beTrue())
+                    }
                 }
             }
             


### PR DESCRIPTION
#### Purpose
- [X] Feature
- [ ] Bug Fix
- [ ] Hotfix
- [ ] Other

#### Associated Tickets
- [Implement Feature Toggles - KIN-79](https://silvercar.atlassian.net/browse/KIN-79)

#### Details
Feature Toggles are enabled if
1) the Feature is enabled and
2) the Strategy evaluates to true (dependent on strategy)

Also changed the parameters of DefaultStrategy to be an empty
dictionary instead of nil (as per Unleash docs/convention).

Inject a strategy into Unleash test object.

#### Checklist
- [X] Tests
- [X] Correct base and merge branches
